### PR TITLE
Updated the Readme file to reflect 2.0.1 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Using this in your Sass stylesheet is pretty easy. Simply import the extension i
 
 If you look at [the extension](https://github.com/adamstac/meyer-reset/blob/master/stylesheets/_meyer-reset.scss), you will notice that we are "including" the mixin `@include meyer-reset` for you in the last line. All you will need to do is import and go.
 
-    @import meyer-reset
+    @import "meyer-reset";
     
     ...
 
@@ -34,7 +34,7 @@ Then use curl to pull down the raw file.
 
 The same rules apply as mentioned above. All you will need to do is import and go.
 
-    @import meyer-reset
+    @import "meyer-reset";
     
     ...
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Then add `require 'meyer-reset'` to your Compass config file.
 
 Using this in your Sass stylesheet is pretty easy. Simply import the extension into your stylesheet (preferably as the first import or declaration in your Sass stylesheet).
 
-If you look at [the extension](https://github.com/adamstac/meyer-reset/blob/master/stylesheets/_meyer-reset.sass), you will notice that we are "including" the mixin `+meyer-reset` for you in the last line. All you will need to do is import and go.
+If you look at [the extension](https://github.com/adamstac/meyer-reset/blob/master/stylesheets/_meyer-reset.scss), you will notice that we are "including" the mixin `@include meyer-reset` for you in the last line. All you will need to do is import and go.
 
     @import meyer-reset
     
@@ -30,30 +30,13 @@ For example: `cd path/to/project/sass`
 
 Then use curl to pull down the raw file.
 
-    curl -0 https://github.com/adamstac/meyer-reset/raw/master/stylesheets/_meyer-reset.sass
+    curl -0 https://github.com/adamstac/meyer-reset/raw/master/stylesheets/_meyer-reset.scss
 
 The same rules apply as mentioned above. All you will need to do is import and go.
 
     @import meyer-reset
     
     ...
-
-### Vanilla CSS
-
-This part of the project was included to just show how much can be done with using Sass as the pre-processor to CSS. As you can see below as well as in the "For Fun" section we can use our Sass code to output our CSS in many ways and do lots of creative things automatically with tools like [Rake](http://en.wikipedia.org/wiki/Rake_(software\)).
-
-If you want to just use the vanilla CSS that this Sass would output check out:
-
-* [stylesheets/compiled/meyer-reset.css](https://github.com/adamstac/meyer-reset/blob/master/stylesheets/compiled/meyer-reset.css)
-* [stylesheets/compiled/meyer-reset-compressed.css](https://github.com/adamstac/meyer-reset/blob/master/stylesheets/compiled/meyer-reset-compressed.css)
-
-Again, using curl, you can pull down either of those as raw files and just use the CSS.
-
-    curl -0 https://github.com/adamstac/meyer-reset/raw/master/stylesheets/compiled/meyer-reset.css
-
-    curl -0 https://github.com/adamstac/meyer-reset/raw/master/stylesheets/compiled/meyer-reset-compiled.css
-    
-To see how these CSS files were created, check out the section below which describes [the various Rake tasks](https://github.com/adamstac/meyer-reset/blob/master/Rakefile) included in this project.
 
 ## For fun
 


### PR DESCRIPTION
Hi,
I updated the Readme.md file to reflect the changes to the gem v 2.0.1
- Removed outdated instructions and links that referred to .sass file and compiled css files. These were removed in v 2.0.1
- Updated instruction to use scss style `@import "meyer-reset";`

I am also getting an error in when I use the gem. I file an issue on your repo with details.

Thanks,
Mark 
