### PR TITLE
Changed the curl url to use new github cdn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For example: `cd path/to/project/sass`
 
 Then use curl to pull down the raw file.
 
-    curl -0 https://github.com/adamstac/meyer-reset/raw/master/stylesheets/_meyer-reset.scss
+    curl -0 https://raw.githubusercontent.com/adamstac/meyer-reset/master/stylesheets/_meyer-reset.scss
 
 The same rules apply as mentioned above. All you will need to do is import and go.
 


### PR DESCRIPTION
The current URL gives me the current output

```
<html><body>You are being <a href="https://raw.githubusercontent.com/adamstac/meyer-reset/master/stylesheets/_meyer-reset.scss">redirected</a>.</body></html>%
```

Therefore this change leverages the new URL directly instead of following redirects via the command line.
